### PR TITLE
Update security settings of favonia/cloudflare-ddns

### DIFF
--- a/ansible/roles/minecraft/templates/docker-compose.yml.j2
+++ b/ansible/roles/minecraft/templates/docker-compose.yml.j2
@@ -98,11 +98,10 @@ services:
     image: favonia/cloudflare-ddns:latest
     network_mode: host
     restart: always
+    user: "1000:1000"
     security_opt:
       - no-new-privileges:true
     environment:
-      - PGID=1000
-      - PUID=1000
       - CF_API_TOKEN={{ cloudflare_api_token_dns }}
       - DOMAINS={{ base_domain }}
       - PROXIED=true

--- a/docker_compose/cloudflare_ddns/docker-compose.yml
+++ b/docker_compose/cloudflare_ddns/docker-compose.yml
@@ -7,11 +7,10 @@ services:
     image: favonia/cloudflare-ddns:latest
     network_mode: host
     restart: always
+    user: "1000:1000"
     security_opt:
       - no-new-privileges:true
     environment:
-      - PGID=1000
-      - PUID=1000
       - CF_API_TOKEN=<PASTE_API_KEY_HERE>
       - DOMAINS=domain.com
       - PROXIED=true


### PR DESCRIPTION
Thanks for using my DDNS updater. Since [version 1.13.0](https://github.com/favonia/cloudflare-ddns/blob/main/CHANGELOG.markdown#1130-2024-07-16) (released on 16 July), the updater has stopped dropping superuser privileges by itself, instead relying on Docker's built-in mechanism to drop those privileges. The new way is safer, cleaner, and more reliable; but it requires an update to the configuration. In particular, the environment variables `PUID=uid` and `PGID=gid` should be replaced by `user: "uid:gid"` or `--user uid:gid`. I am on a mission to eliminate the old template from the internet. Please help me promote security best practices!

For more information about this design change, please read the [CHANGELOG](https://github.com/favonia/cloudflare-ddns/blob/main/CHANGELOG.markdown). If copyright ever matters, this PR itself is licensed under [CC0](https://choosealicense.com/licenses/cc0-1.0/), which should allow you to do whatever you want. Thank you again for your interest in the updater.

_PS:_ I also recommend adding `cap_drop: [all]` and Docker's other protections. See [README](https://github.com/favonia/cloudflare-ddns/blob/main/README.markdown).